### PR TITLE
Refactor collision detection algo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,6 +16,7 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 name = "bwb"
 version = "0.1.0"
 dependencies = [
+ "itertools",
  "rand",
  "rayon",
  "sdl2",
@@ -105,6 +106,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "itertools"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+dependencies = [
+ "either",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 sdl2 = "0.34.3"
 rand = "0.4.2"
 rayon = "1.5.0"
+itertools = "0.9.0"
 
 [profile.release]
 debug = true

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -10,6 +10,11 @@ use crate::render::Renderer;
 
 const MAX_FPS: u32 = 60; // Max FPS. Set this low to observe effects.
 
+fn print_framerate(frame_time: i32) {
+    let frame_rate = 1.0 / (frame_time as f32 / 1000.0);
+    println!("{}", frame_rate);
+}
+
 pub fn run(mut curr_level: i32) {
     let (mut world, mut obj_factory) = levels::init(curr_level);
     let sdl_context = sdl2::init().unwrap();
@@ -85,6 +90,10 @@ pub fn run(mut curr_level: i32) {
                     keycode: Some(Keycode::Down),
                     ..
                 } => move_cannon(&mut world, Direction::Down),
+                Event::KeyDown {
+                    keycode: Some(Keycode::F),
+                    ..
+                } => print_framerate(frame_time),
                 Event::Quit { .. }
                 | Event::KeyDown {
                     keycode: Some(Keycode::Escape),

--- a/src/game_logic.rs
+++ b/src/game_logic.rs
@@ -150,7 +150,7 @@ fn detect_and_handle_collisions(
             to_remove_2.insert(baddie_id);
         };
 
-        let cannon_baddie_handler = |cannon_id: EntityId, baddie_id: EntityId| {
+        let baddie_cannon_handler = |baddie_id: EntityId, cannon_id: EntityId| {
             to_remove_3.insert(baddie_id);
             let cannon_health = healths.get_mut(&cannon_id).unwrap();
             let new_health = *cannon_health - 1;
@@ -167,7 +167,7 @@ fn detect_and_handle_collisions(
             Box::new(baddie_wall_handler),
             Box::new(bullet_wall_handler),
             Box::new(bullet_baddie_handler),
-            Box::new(cannon_baddie_handler),
+            Box::new(baddie_cannon_handler),
         );
         collision_system.process(&wall_geoms, &baddie_geoms, &bullet_geoms, &cannon_geoms);
     }

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -151,7 +151,14 @@ pub fn direction_vector(direction: Direction) -> Vector {
     }
 }
 
-
+/// Calculates the square of a box's side length. Assumes square box.
+pub fn box_side_len_sqr(geom: &Geometry) -> i32 {
+    let (x0, y0) = geom[0];
+    let (x1, y1) = geom[1];
+    let dx = x1 - x0;
+    let dy = y1 - y0;
+    dx * dx + dy * dy
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 //! # Bullets, Walls and Baddies v1  
-
 extern crate sdl2;
 extern crate rayon;
+extern crate itertools;
 
 mod collision_system;
 mod engine;
@@ -15,5 +15,7 @@ mod shape;
 mod world;
 
 pub fn main() {
-    engine::run(99);
+    // single threaded for debugging
+    //rayon::ThreadPoolBuilder::new().num_threads(1).build_global().unwrap();
+    engine::run(3);
 }


### PR DESCRIPTION
Refactored to reduce nesting e.g. more use of iterators. Made it a bit more general and applied DRY. In theory, this could have a few more iterations, but in practise won't make much difference.
Also found false negative detections for earlier levels as a result of bin size, so made bin size adaptive.
Finally, added a 'Press F to print framerate' basic debug feature.